### PR TITLE
Add deidentification project in component_def

### DIFF
--- a/python/brainvisa/maker/components_definition.py
+++ b/python/brainvisa/maker/components_definition.py
@@ -522,6 +522,16 @@ components_definition = [
             }],
         ],
     }),
+    ('deidentification', {
+        'components': [
+            ['deidentification', {
+                'groups': ['cati_platform'],
+                'branches': {
+                    'bug_fix': ('git https://github.com/cati-neuroimaging/deidentification.git default:master', 'deidentification'),
+                },
+            }],
+        ],
+    }),
     ('fmri', {
         'description': 'Functional MRI processing toolboxes.',
         'components': [


### PR DESCRIPTION
Add `deidentification` project in components_definition for `cati_platform` installation. 
Deidentification is a CATI project as a python module used to deidentify DICOM headers.

I only added it into the `cati_platform` group, I do not know if it is necessary to add it to the `all` group too?