### PR TITLE
Update code for Python 3

### DIFF
--- a/bin/bv_system_info
+++ b/bin/bv_system_info
@@ -131,9 +131,9 @@ else:
 
 if __name__ == "__main__":
     if len(sys.argv) > 1:
-        if sys.argv[1] == "-p" or sys.argv[1] == "--platform":
+        if sys.argv[1] in ("-p", "--platform"):
             print(systemplatform)
-        elif sys.argv[1] == "-s" or sys.argv[1] == "--shortname":
+        elif sys.argv[1] in ("-s", "--shortname"):
             print(shortname)
         else:
             print(" Get system identification information ")

--- a/bin/bv_system_info
+++ b/bin/bv_system_info
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
-from __future__ import absolute_import, print_function
 
 import sys
 import os


### PR DESCRIPTION
* `pyupgrade --py36-plus`
* `refurb`
  ```
   [FURB108]: Use `x in (y, z)` instead of `x == y or x == z`
   ```