### PR TITLE
Set variable PYTHON_INSTALL_DIRECTORY

### DIFF
--- a/python/brainvisa/maker/build.py
+++ b/python/brainvisa/maker/build.py
@@ -498,7 +498,7 @@ if len(old_file) == 0:
                     file=out)
                 print('set( ' + component + '_VERSION "' + version + '" )',
                       file=out)
-
+            print('set(PYTHON_INSTALL_DIRECTORY python)', file=out)
         cmakeLists = os.path.join(self.directory, 'CMakeLists.txt')
 
         with open(cmakeLists, 'w') as out:


### PR DESCRIPTION
This variable must be used in projects CMake files instead of using the "python" string. To date it is not used in brainvisa-cmake but it will allow to modify other projects to use it so that they are compatible for a build with Conda. The `conda` branch of brainvisa-cmake changes the definition of this variable.